### PR TITLE
Add option to configure readiness- and livenessProbes

### DIFF
--- a/charts/metaphactory/templates/statefulset.yaml
+++ b/charts/metaphactory/templates/statefulset.yaml
@@ -59,19 +59,12 @@ spec:
           limits:
             cpu: {{ .Values.container.resources.cpuLimit }}
             memory: {{ .Values.container.resources.memoryLimit }}
-        readinessProbe:
-          httpGet:
-            path: /login
-            port: 8080
-          initialDelaySeconds: 120
-          failureThreshold: 10
-          periodSeconds: 10
-        livenessProbe:
-          httpGet:
-            path: /login
-            port: 8080
-          failureThreshold: 3
-          periodSeconds: 120
+        {{- with .Values.container.readinessProbe }}
+        readinessProbe: {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.container.livenessProbe }}
+        livenessProbe: {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - mountPath: /runtime-data
           name: {{ .Values.container.name }}-runtime-data

--- a/charts/metaphactory/values.yaml
+++ b/charts/metaphactory/values.yaml
@@ -12,6 +12,19 @@ container:
     memoryRequest: "1Gi"
     cpuLimit: "500m"
     memoryLimit: "2Gi"
+  readinessProbe:
+    httpGet:
+      path: /login
+      port: 8080
+    initialDelaySeconds: 120
+    failureThreshold: 10
+    periodSeconds: 10
+  livenessProbe:
+    httpGet:
+      path: /login
+      port: 8080
+    failureThreshold: 3
+    periodSeconds: 120
   affinity: {}
   envFrom: []
 #appsFromVolumes:


### PR DESCRIPTION
In this PR I add the functionality to configure the probes by passing / adjusting them in the `values.yaml`.
I verified the output by doing a `helm template metaphactory ./charts/metaphactory/ -f ./charts/metaphactory/values.yaml > generated.yaml`